### PR TITLE
Added name reference to drugs and diseases on GraphQL

### DIFF
--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/domain/DiseaseRepository.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/domain/DiseaseRepository.kt
@@ -3,4 +3,6 @@ package app.ubie.kotlingraphqlsample.domain
 interface DiseaseRepository {
     fun getDiseases(icd: String): List<Disease>
     fun getDiseases(icds: List<String>): List<Disease>
+
+    fun getDiseasesByName(name: String): List<Disease>
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/domain/DrugRepository.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/domain/DrugRepository.kt
@@ -3,4 +3,6 @@ package app.ubie.kotlingraphqlsample.domain
 interface DrugRepository {
     fun getDrugs(yjCode: String): List<Drug>
     fun getDrugs(yjCodes: List<String>): List<Drug>
+
+    fun getDrugsByName(name: String): List<Drug>
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/infrastructure/jdbc/JdbcDiseaseRepository.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/infrastructure/jdbc/JdbcDiseaseRepository.kt
@@ -45,4 +45,19 @@ class JdbcDiseaseRepository(private val jdbcTemplate: NamedParameterJdbcTemplate
                   icd IN (:icd)
                 """.trimIndent(), mapOf("icd" to targets), rowMapper)
     }
+
+    override fun getDiseasesByName(name: String): List<Disease> {
+        if (name.isBlank()) return emptyList()
+        //language=SQL
+        return jdbcTemplate.query(
+                """
+                SELECT
+                  icd,
+                  name
+                FROM
+                  disease
+                WHERE
+                  name = :name
+                """.trimIndent(), mapOf("name" to name), rowMapper)
+    }
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/infrastructure/jdbc/JdbcDrugRepository.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/infrastructure/jdbc/JdbcDrugRepository.kt
@@ -48,4 +48,20 @@ class JdbcDrugRepository(private val jdbcTemplate: NamedParameterJdbcTemplate) :
                 """.trimIndent(), mapOf("yj_codes" to yjCodes), rowMapper
         )
     }
+
+    override fun getDrugsByName(name: String): List<Drug> {
+        if (name.isBlank()) return emptyList()
+        //language=SQL
+        return jdbcTemplate.query(
+                """
+                SELECT
+                  name,
+                  yj_code
+                FROM
+                  drug
+                WHERE
+                  name = :name
+                """.trimIndent(), mapOf("name" to name), rowMapper
+        )
+    }
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/presentation/queryresolver/DiseaseQueryResolver.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/presentation/queryresolver/DiseaseQueryResolver.kt
@@ -12,4 +12,9 @@ class DiseaseQueryResolver(private val service: DiseaseService) : GraphQLQueryRe
         if (icd.isEmpty()) throw IllegalArgumentException("icd must not be empty")
         return service.getDiseases(icd)
     }
+
+    fun diseasesByName(name: String): List<Disease> {
+        if (name.isEmpty()) throw IllegalArgumentException("name must not be empty")
+        return service.getDiseasesByName(name)
+    }
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/presentation/queryresolver/DrugQueryResolver.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/presentation/queryresolver/DrugQueryResolver.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Component
 @Component
 class DrugQueryResolver(val drugService: DrugService) : GraphQLQueryResolver {
     fun drugs(yjCode: String): List<Drug> = drugService.getDrugs(yjCode)
+
+    fun drugsByName(name: String): List<Drug> = drugService.getDrugsByName(name)
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/service/DiseaseService.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/service/DiseaseService.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Service
 class DiseaseService(private val repository: DiseaseRepository) {
     fun getDiseases(icd: String): List<Disease> = repository.getDiseases(icd)
     fun getDiseases(icds: List<String>): List<Disease> = repository.getDiseases(icds)
+
+    fun getDiseasesByName(name: String): List<Disease> = repository.getDiseasesByName(name)
 }

--- a/src/main/kotlin/app/ubie/kotlingraphqlsample/service/DrugService.kt
+++ b/src/main/kotlin/app/ubie/kotlingraphqlsample/service/DrugService.kt
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Service
 class DrugService(private val repository: DrugRepository) {
     fun getDrugs(yjCode: String): List<Drug> = repository.getDrugs(yjCode)
     fun getDrugs(yjCodes: List<String>): List<Drug> = repository.getDrugs(yjCodes)
+
+    fun getDrugsByName(name: String): List<Drug> = repository.getDrugsByName(name)
 }

--- a/src/main/resources/graphql/kotlingraphqlsample.graphqls
+++ b/src/main/resources/graphql/kotlingraphqlsample.graphqls
@@ -5,6 +5,14 @@ type Query {
     diseases(icd: String!) : [Disease!]
 }
 
+extend type Query {
+    # 名前で取得
+    # 薬
+    drugsByName(name: String!) : [Drug!]
+    # 病気
+    diseasesByName(name: String!) : [Disease!]
+}
+
 # 薬情報
 type Drug {
     # 薬品名


### PR DESCRIPTION
Different from the other pull request, this is the one for GraphQL. You can get the data of drugs and diseases on GraphiQL by name using drugsByName(name: String) or diseasesByName(name: String)