### PR TITLE
kotlinを1.4.30に更新、docker-composeの設定を分けてlocalでもアプリを起動できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@
 以下のコマンドを実行します。
 
 ```
-docker-compose up
+./docker-compose up
 ```
 
 起動した状態で http://localhost:8090/graphiql にアクセスすると、GraphiQLにアクセス出来ます。
+
+## localでSpring Boot Appを起動する場合
+
+`docker-compose-middleware.yml`でデータベースを起動して、IntelliJ上でKotlinGraphQLSampleApplicationを実行してください。
+
+```
+docker-compose -f docker-compose-middleware.yml up
+```
 
 ## テスト
 

--- a/docker-compose
+++ b/docker-compose
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose-app.yml -f docker-compose-middleware.yml $1

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,21 +1,14 @@
 version: '3'
 services:
-  db:
-    image: postgres:9.6.6
-    container_name: sample-db
-    ports:
-    - 5435:5432
-    expose:
-    - 5435
   app:
     image: openjdk:10
     container_name: sample-app
     ports:
     - 8090:8089
-    links:
-    - db
     volumes:
     - .:/app
     - ~/.config/:/root/.config
     working_dir: /app
+    environment:
+      - JDBC_HOST=sample-db
     command: ./gradlew bootRun

--- a/docker-compose-middleware.yml
+++ b/docker-compose-middleware.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.6.6
+    container_name: sample-db
+    ports:
+      - 5432:5432
+    expose:
+      - 5432

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.3.11
+kotlinVersion=1.4.30
 springBootVersion=2.1.0.RELEASE
 graphqlSpringVersion=5.0.4
 junitVersion=5.3.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 spring:
   datasource:
     driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://sample-db:5432/postgres
+    url: jdbc:postgresql://${JDBC_HOST:localhost}:5432/postgres
     username: postgres
     password:
   cloud:


### PR DESCRIPTION
# やったこと

- kotlinを1.4.30に更新した
- docker-composeの設定を分けてlocalでもアプリを起動できるようにした
  - application.ymlのdb設定で環境変数を使うスタイルにし、docker場合にservice nameをセットする形にした
  - docker-compose-app.yml, docker-compose-middleware.ymlに分けた。`docker-compose -f docker-compose-middleware.yml up`でdbだけ起動して、localでSpring Boot Appを起動して繋げられるようになった